### PR TITLE
update for Xcode6 Beta4

### DIFF
--- a/XCGLogger/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/XCGLogger/XCGLogger.swift
@@ -363,8 +363,10 @@ class XCGLogger : DebugPrintable {
         let functionNameDuplicateLength = functionNameDuplicate.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)
         let functionNameLength = functionName.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)
         if functionNameLength < functionNameDuplicateLength {
-            let range: Range = functionNameDuplicate.rangeOfString(functionName, options: .LiteralSearch)
-            realFunctionName = functionNameDuplicate.stringByReplacingCharactersInRange(range, withString: "")
+            let range: Range? = functionNameDuplicate.rangeOfString(functionName, options: .LiteralSearch)
+            if (range) {
+                realFunctionName = functionNameDuplicate.stringByReplacingCharactersInRange(range!, withString: "")
+            }
         }
 
         var logDetails: XCGLogDetails? = nil


### PR DESCRIPTION
Quick fix for the compiler error under Xcode6 Beta4, seems string.rangeOfString() returns optional result now.
