### PR TITLE
Workaround for Swift compiler optimizer bug

### DIFF
--- a/XCGLogger/Library/XCGLogger.xcodeproj/project.pbxproj
+++ b/XCGLogger/Library/XCGLogger.xcodeproj/project.pbxproj
@@ -355,7 +355,7 @@
 				PRODUCT_NAME = XCGLogger;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Release;
 		};
@@ -478,7 +478,7 @@
 				PRODUCT_MODULE_NAME = XCGLogger;
 				PRODUCT_NAME = XCGLogger;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Release;
 		};

--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -423,7 +423,10 @@ public class XCGLogger : DebugPrintable {
     }
 
     public func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
-        if (!isEnabledForLogLevel(logLevel)) {
+        // Don't call isEnabledForLogLevel() here, causes compiler crash when
+        // optimization level is set to Fastest [-O]. See issues #10, #17, #26.
+        // Inlined the method here as a workaround.
+        if (!(logLevel >= self.outputLogLevel)) {
             return
         }
 


### PR DESCRIPTION
Figured this out in the process of trying to pinpoint the crash to submit to the [swift-compiler-crashes](https://github.com/practicalswift/swift-compiler-crashes/pull/38) project.

- Set release mode optimization level back to "Fastest [-O]" for both iOS & OS X
- Tests pass
- In ref to:
    - https://github.com/DaveWoodCom/XCGLogger/issues/10
    - https://github.com/DaveWoodCom/XCGLogger/issues/17
    - https://github.com/DaveWoodCom/XCGLogger/issues/26