### PR TITLE
Tracing with full type ahead.

### DIFF
--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -477,6 +477,14 @@ public class XCGLogger : DebugPrintable {
         self.logln(logMessage, logLevel: .Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
+    public class func trace(functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().debug("", functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func trace(functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln("", logLevel: .Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+    
     public class func info(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.defaultInstance().info(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }

--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -176,7 +176,7 @@ public class XCGFileLogDestination : XCGLogDestinationProtocol, DebugPrintable {
         self.identifier = identifier
 
         if writeToFile is NSString {
-            writeToFileURL = NSURL.fileURLWithPath(writeToFile as String)
+            writeToFileURL = NSURL.fileURLWithPath(writeToFile as! String)
         }
         else if writeToFile is NSURL {
             writeToFileURL = writeToFile as? NSURL
@@ -374,7 +374,7 @@ public class XCGLogger : DebugPrintable {
 
         if let unwrappedLogDestination: XCGLogDestinationProtocol = logDestination(XCGLogger.constants.baseConsoleLogDestinationIdentifier) {
             if unwrappedLogDestination is XCGConsoleLogDestination {
-                let standardConsoleLogDestination = unwrappedLogDestination as XCGConsoleLogDestination
+                let standardConsoleLogDestination = unwrappedLogDestination as! XCGConsoleLogDestination
 
                 standardConsoleLogDestination.showLogLevel = showLogLevel
                 standardConsoleLogDestination.showFileName = showFileNames
@@ -477,14 +477,6 @@ public class XCGLogger : DebugPrintable {
         self.logln(logMessage, logLevel: .Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public class func trace(functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().debug("", functionName: functionName, fileName: fileName, lineNumber: lineNumber)
-    }
-
-    public func trace(functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.logln("", logLevel: .Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
-    }
-    
     public class func info(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.defaultInstance().info(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }


### PR DESCRIPTION
Gentlefolk,


I am always adding trace statements in my code to log execution pathways during debugging. To that end, I've added a trace() method to this class.

It is the debug method with an empty string. Why? Because Xcode's type ahead will fully fill it in.

Share and enjoy,
Andrew
