### PR TITLE
Set the "Allow App Extensions API Only" flag

### DIFF
--- a/XCGLogger/Library/XCGLogger.xcodeproj/project.pbxproj
+++ b/XCGLogger/Library/XCGLogger.xcodeproj/project.pbxproj
@@ -447,6 +447,7 @@
 		55E3EE5C19D76F280068C3A7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUNDLE_IDENTIFIER = com.cerebralgardens.xcglogger;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
@@ -466,6 +467,7 @@
 		55E3EE5D19D76F280068C3A7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUNDLE_IDENTIFIER = com.cerebralgardens.xcglogger;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
This patch sets the "Allow App Extensions API Only" flag.

This does not affect any code inside XCGLogger because it does not use any API that is not available in App Extensions. It does however stop Xcode from complaining when using this framework in App Extensions.

The link error that we get for the Firefox for iOS project is this:

> ld: warning: linking against dylib not safe for use in application extensions: /Users/sarentz/Library/Developer/Xcode/DerivedData/Firefox-ccfiyfdswuakzzclvczxupjmjmcy/Build/Products/Debug-iphonesimulator/XCGLogger.framework/XCGLogger

