### PR TITLE
Unify level and levelExec functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,24 +88,28 @@ You can create alternate log destinations (besides the two built in ones for the
 Each log destination can have its own log level. Setting the log level on the log object itself will pass that level to each destination. Then set the destinations that need to be different.
 
 ###Selectively Executing Code
-As of version 1.2, you can now also selectively execute code based on the log level. This is useful for cases where you have to do some work in order to generate a log message, but don't want to do that work when the log messages won't be printed anyway.
+As of version 1.9, all log methods operate on closures. Using the same syntactic sugar as Swift's ```assert()``` function, this approach ensures we don't waste resources building log messages that won't be printed anyway, while at the same time preserving a clean call site.
 
-For example, if you have to iterate through a loop in order to do some calculation before logging the result. In Objective-C, you could put that code block between ```#if``` ```#endif```, and prevent the code from running. But in Swift, previously you would need to still process that loop, wasting resources.
+For example, the following log statement won't waste resources if the debug log level is suppressed:
 
 ```Swift
-log.debugExec {
-    var total = 0.0
-    for receipt in receipts {
-	    total += receipt.total
-    }
-
-    log.debug("Total of all receipts: \(total)")
-}
-
+log.debug("The description of \(thisObject) is really expensive to create")
 ```
 
-There are convenience methods for each log level:
-```verboseExec```, ```debugExec```, ```infoExec```, ```warningExec```, ```errorExec```, ```severeExec```
+Similarly, let's say you have to iterate through a loop in order to do some calculation before logging the result. In Objective-C, you could put that code block between ```#if``` ```#endif```, and prevent the code from running. But in Swift, previously you would need to still process that loop, wasting resources. With ```XCGLogger``` it's as simple as:
+
+```Swift
+log.debug {
+    var total = 0.0
+    for receipt in receipts {
+        total += receipt.total
+    }
+
+    return "Total of all receipts: \(total)"
+}
+```
+
+Version 1.2 introduced ```verboseExec```, ```debugExec```, ```infoExec```, ```warningExec```, ```errorExec```, and ```severeExec``` to solve this problem. As of version 1.9, that approach has been deprecated.
 
 ###To Do
 - Add examples of some advanced use cases
@@ -134,5 +138,4 @@ Also, please check out my book **Swift for the Really Impatient** http://swiftfo
 * **Version 1.2**: *(2014/07/01)* - Added exec methods to selectively execute code
 * **Version 1.1**: *(2014/06/22)* - Changed the internal architecture to allow for more flexibility
 * **Version 1.0**: *(2014/06/09)* - Initial Release
-
 

--- a/XCGLogger/DemoApps/OSX/OSXDemo/OSXDemo/AppDelegate.swift
+++ b/XCGLogger/DemoApps/OSX/OSXDemo/OSXDemo/AppDelegate.swift
@@ -39,43 +39,43 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Main View
     @IBAction func verboseButtonTouchUpInside(sender : AnyObject) {
         log.verbose("Verbose button tapped")
-        log.verboseExec {
-            log.verbose("Executed verbose code block")
+        log.verbose {
+            "Executed verbose code block"
         }
     }
 
     @IBAction func debugButtonTouchUpInside(sender : AnyObject) {
         log.debug("Debug button tapped")
-        log.debugExec {
-            log.debug("Executed debug code block")
+        log.debug {
+            "Executed debug code block"
         }
     }
 
     @IBAction func infoButtonTouchUpInside(sender : AnyObject) {
         log.info("Info button tapped")
-        log.infoExec {
-            log.info("Executed info code block")
+        log.info {
+            "Executed info code block"
         }
     }
 
     @IBAction func warningButtonTouchUpInside(sender : AnyObject) {
         log.warning("Warning button tapped")
-        log.warningExec {
-            log.warning("Executed warning code block")
+        log.warning {
+            "Executed warning code block"
         }
     }
 
     @IBAction func errorButtonTouchUpInside(sender : AnyObject) {
         log.error("Error button tapped")
-        log.errorExec {
-            log.error("Executed error code block")
+        log.error {
+            "Executed error code block"
         }
     }
 
     @IBAction func severeButtonTouchUpInside(sender : AnyObject) {
         log.severe("Severe button tapped")
-        log.severeExec {
-            log.severe("Executed severe code block")
+        log.severe {
+            "Executed severe code block"
         }
     }
 

--- a/XCGLogger/DemoApps/iOS/iOSDemo/iOSDemo/AppDelegate.swift
+++ b/XCGLogger/DemoApps/iOS/iOSDemo/iOSDemo/AppDelegate.swift
@@ -20,23 +20,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var documentsDirectory: NSURL {
         let urls = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)
-        return urls[urls.endIndex-1] as NSURL
+        return urls[urls.endIndex-1] as! NSURL
     }
 
     var cacheDirectory: NSURL {
         let urls = NSFileManager.defaultManager().URLsForDirectory(.CachesDirectory, inDomains: .UserDomainMask)
-        return urls[urls.endIndex-1] as NSURL
+        return urls[urls.endIndex-1] as! NSURL
     }
 
     // MARK: - Life cycle methods
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func applicationDidFinishLaunching(application: UIApplication) {
         // Override point for customization after application launch.
 
         // Setup XCGLogger
         let logPath : NSURL = self.cacheDirectory.URLByAppendingPathComponent("XCGLogger_Log.txt")
         log.setup(logLevel: .Debug, showLogLevel: true, showFileNames: true, showLineNumbers: true, writeToFile: logPath)
-
-        return true
     }
 
     func applicationWillResignActive(application: UIApplication) {

--- a/XCGLogger/DemoApps/iOS/iOSDemo/iOSDemo/ViewController.swift
+++ b/XCGLogger/DemoApps/iOS/iOSDemo/iOSDemo/ViewController.swift
@@ -26,43 +26,43 @@ class ViewController: UIViewController {
 
     @IBAction func verboseButtonTouchUpInside(sender : AnyObject) {
         log.verbose("Verbose button tapped")
-        log.verboseExec {
-            log.verbose("Executed verbose code block")
+        log.verbose {
+            "Executed verbose code block"
         }
     }
 
     @IBAction func debugButtonTouchUpInside(sender : AnyObject) {
         log.debug("Debug button tapped")
-        log.debugExec {
-            log.debug("Executed debug code block")
+        log.debug {
+            "Executed debug code block"
         }
     }
 
     @IBAction func infoButtonTouchUpInside(sender : AnyObject) {
         log.info("Info button tapped")
-        log.infoExec {
-            log.info("Executed info code block")
+        log.info {
+            "Executed info code block"
         }
     }
 
     @IBAction func warningButtonTouchUpInside(sender : AnyObject) {
         log.warning("Warning button tapped")
-        log.warningExec {
-            log.warning("Executed warning code block")
+        log.warning {
+            "Executed warning code block"
         }
     }
 
     @IBAction func errorButtonTouchUpInside(sender : AnyObject) {
         log.error("Error button tapped")
-        log.errorExec {
-            log.error("Executed error code block")
+        log.error {
+            "Executed error code block"
         }
     }
 
     @IBAction func severeButtonTouchUpInside(sender : AnyObject) {
         log.severe("Severe button tapped")
-        log.severeExec {
-            log.severe("Executed severe code block")
+        log.severe {
+            "Executed severe code block"
         }
     }
 

--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -399,17 +399,30 @@ public class XCGLogger : DebugPrintable {
     }
 
     // MARK: - Logging methods
-    public class func logln(logMessage: String, logLevel: LogLevel = .Debug, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().logln(logMessage, logLevel: logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public class func logln(closure: @autoclosure () -> String, logLevel: LogLevel = .Debug, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().logln(closure: closure, logLevel: logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public func logln(logMessage: String, logLevel: LogLevel = .Debug, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+    public class func logln(closure: () -> String, logLevel: LogLevel = .Debug, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().logln(closure: closure, logLevel: logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func logln(closure: @autoclosure () -> String, logLevel: LogLevel = .Debug, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func logln(closure: () -> String, logLevel: LogLevel = .Debug, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    private func logln(#closure: () -> String, logLevel: LogLevel = .Debug, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         let date = NSDate()
 
         var logDetails: XCGLogDetails? = nil
         for logDestination in self.logDestinations {
             if (logDestination.isEnabledForLogLevel(logLevel)) {
                 if logDetails == nil {
+                    let logMessage = closure()
                     logDetails = XCGLogDetails(logLevel: logLevel, date: date, logMessage: logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
                 }
 
@@ -418,10 +431,12 @@ public class XCGLogger : DebugPrintable {
         }
     }
 
+    @availability(*, deprecated = 1.9)
     public class func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel: logLevel, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
         if (!isEnabledForLogLevel(logLevel)) {
             return
@@ -461,98 +476,158 @@ public class XCGLogger : DebugPrintable {
     }
 
     // MARK: - Convenience logging methods
-    public class func verbose(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().verbose(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public class func verbose(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().verbose(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public func verbose(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.logln(logMessage, logLevel: .Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public class func verbose(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().verbose(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public class func debug(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().debug(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public func verbose(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public func debug(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.logln(logMessage, logLevel: .Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public func verbose(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public class func info(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().info(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public class func debug(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().debug(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public func info(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.logln(logMessage, logLevel: .Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public class func debug(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().debug(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public class func warning(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().warning(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public func debug(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public func warning(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.logln(logMessage, logLevel: .Warning, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
-    }
-    
-    public class func error(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().error(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public func debug(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public func error(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.logln(logMessage, logLevel: .Error, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
-    }
-    
-    public class func severe(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.defaultInstance().severe(logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public class func info(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().info(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
-    public func severe(logMessage: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
-        self.logln(logMessage, logLevel: .Severe, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    public class func info(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().info(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 
+    public func info(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func info(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public class func warning(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().warning(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public class func warning(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().warning(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func warning(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Warning, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func warning(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Warning, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public class func error(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().error(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public class func error(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().error(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func error(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Error, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func error(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Error, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public class func severe(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().severe(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public class func severe(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.defaultInstance().severe(closure, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func severe(closure: @autoclosure () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Severe, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    public func severe(closure: () -> String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+        self.logln(closure: closure, logLevel: .Severe, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+
+    @availability(*, deprecated = 1.9)
     public class func verboseExec(closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel: XCGLogger.LogLevel.Verbose, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public func verboseExec(closure: () -> () = {}) {
         self.exec(logLevel: XCGLogger.LogLevel.Verbose, closure: closure)
     }
     
+    @availability(*, deprecated = 1.9)
     public class func debugExec(closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel: XCGLogger.LogLevel.Debug, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public func debugExec(closure: () -> () = {}) {
         self.exec(logLevel: XCGLogger.LogLevel.Debug, closure: closure)
     }
     
+    @availability(*, deprecated = 1.9)
     public class func infoExec(closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel: XCGLogger.LogLevel.Info, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public func infoExec(closure: () -> () = {}) {
         self.exec(logLevel: XCGLogger.LogLevel.Info, closure: closure)
     }
     
+    @availability(*, deprecated = 1.9)
     public class func warningExec(closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel: XCGLogger.LogLevel.Warning, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public func warningExec(closure: () -> () = {}) {
         self.exec(logLevel: XCGLogger.LogLevel.Warning, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public class func errorExec(closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel: XCGLogger.LogLevel.Error, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public func errorExec(closure: () -> () = {}) {
         self.exec(logLevel: XCGLogger.LogLevel.Error, closure: closure)
     }
     
+    @availability(*, deprecated = 1.9)
     public class func severeExec(closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel: XCGLogger.LogLevel.Severe, closure: closure)
     }
 
+    @availability(*, deprecated = 1.9)
     public func severeExec(closure: () -> () = {}) {
         self.exec(logLevel: XCGLogger.LogLevel.Severe, closure: closure)
     }

--- a/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
+++ b/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
@@ -93,6 +93,26 @@ class XCGLoggerTests: XCTestCase {
         XCTAssert(logDestinationCountAfterAddition == logDestinationCountAfterAddition2, "Failed to prevent adding additional logger with a duplicate identifier")
     }
 
+    func testAvoidStringInterpolationWithAutoclosure() {
+        var log: XCGLogger = XCGLogger()
+        log.identifier = "com.cerebralgardens.xcglogger.testAvoidStringInterpolationWithAutoclosure"
+        log.outputLogLevel = .Debug
+
+        class ObjectWithExpensiveDescription: Printable {
+            var descriptionInvoked = false
+
+            var description: String {
+                descriptionInvoked = true
+                return "expensive"
+            }
+        }
+
+        let thisObject = ObjectWithExpensiveDescription()
+
+        log.verbose("The description of \(thisObject) is really expensive to create" )
+        XCTAssert(!thisObject.descriptionInvoked, "Fail: String was interpolated when it shouldn't have been")
+    }
+
     func testExecExecutes() {
         var log: XCGLogger = XCGLogger()
         log.identifier = "com.cerebralgardens.xcglogger.testExecExecutes"

--- a/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
+++ b/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
@@ -109,7 +109,7 @@ class XCGLoggerTests: XCTestCase {
 
         let thisObject = ObjectWithExpensiveDescription()
 
-        log.verbose("The description of \(thisObject) is really expensive to create" )
+        log.verbose("The description of \(thisObject) is really expensive to create")
         XCTAssert(!thisObject.descriptionInvoked, "Fail: String was interpolated when it shouldn't have been")
     }
 
@@ -119,7 +119,7 @@ class XCGLoggerTests: XCTestCase {
         log.outputLogLevel = .Debug
 
         var executed: Bool = false
-        log.debugExec {
+        log.internalExec {
             log.debug("executed closure correctly")
             executed = true
         }
@@ -134,7 +134,7 @@ class XCGLoggerTests: XCTestCase {
         log.outputLogLevel = .Error
 
         var executed: Bool = false
-        log.debugExec {
+        log.internalExec {
             log.debug("executed closure incorrectly")
             executed = true
         }
@@ -151,7 +151,7 @@ class XCGLoggerTests: XCTestCase {
 
         let linesToLog = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]
         let myConcurrentQueue = dispatch_queue_create("com.cerebralgardens.xcglogger.testMultiThreaded.queue", DISPATCH_QUEUE_CONCURRENT)
-        dispatch_apply(UInt(linesToLog.count), myConcurrentQueue) { (index: UInt) in
+        dispatch_apply(linesToLog.count, myConcurrentQueue) { (index: Int) in
             log.debug(linesToLog[Int(index)])
         }
     }


### PR DESCRIPTION
* Simplify the logging API with assert-inspired @autoclosures;
* Deprecate the no-longer-necessary levelExec methods;
* Improve performance by avoiding unnecessary String interpolation and
  add unit test to confirm the same;
* Replace levelExec calls in the demo apps to use the new @autoclosures;
* Update README.md with example usage.