### PR TITLE
Fix message describing the assert failure in testExecDoesntExecute()

### DIFF
--- a/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
+++ b/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
@@ -156,7 +156,7 @@ class XCGLoggerTests: XCTestCase {
 
         log.outputLogLevel = .Debug
         log.debug("executed: \(numberOfTimes) time(s)")
-        XCTAssert(numberOfTimes == 0, "Fail: Didn't execute the closure when it should have")
+        XCTAssert(numberOfTimes == 0, "Fail: Executed the closure when it shouldn't have")
     }
 
     func testMultiThreaded() {


### PR DESCRIPTION
Looks like a copy & paste error.