### PR TITLE
Swift 2.0 Xcode B5 Update

### DIFF
--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -85,7 +85,8 @@ public class XCGConsoleLogDestination: XCGLogDestinationProtocol, CustomDebugStr
         }
 
         if showFileName {
-            extendedDetails += "[" + logDetails.fileName.lastPathComponent + (showLineNumber ? ":" + String(logDetails.lineNumber) : "") + "] "
+            let path = logDetails.fileName as NSString
+            extendedDetails += "[" + path.lastPathComponent + (showLineNumber ? ":" + String(logDetails.lineNumber) : "") + "] "
         }
         else if showLineNumber {
             extendedDetails += "[" + String(logDetails.lineNumber) + "] "
@@ -204,7 +205,8 @@ public class XCGFileLogDestination: XCGLogDestinationProtocol, CustomDebugString
         }
 
         if showFileName {
-            extendedDetails += "[" + logDetails.fileName.lastPathComponent + (showLineNumber ? ":" + String(logDetails.lineNumber) : "") + "] "
+            let path = logDetails.fileName as NSString
+            extendedDetails += "[" + path.lastPathComponent + (showLineNumber ? ":" + String(logDetails.lineNumber) : "") + "] "
         }
         else if showLineNumber {
             extendedDetails += "[" + String(logDetails.lineNumber) + "] "

--- a/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
+++ b/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
@@ -166,7 +166,8 @@ class XCGLoggerTests: XCTestCase {
         let linesToLog = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]
         let myConcurrentQueue = dispatch_queue_create("com.cerebralgardens.xcglogger.testMultiThreaded.queue", DISPATCH_QUEUE_CONCURRENT)
         dispatch_apply(linesToLog.count, myConcurrentQueue) { (index: Int) in
-            log.debug(linesToLog[Int(index)])
+            let logLines = linesToLog[Int(index)]
+            log.debug(logLines)
         }
     }
     


### PR DESCRIPTION
B5 removed several methods / properties, including lastPathComponent, from String. For now we can get around this by casting back to NSString. Not sure if this is a permanent move by them or if they really do want us to be more explicit when working with file system paths. Nothing available in the notes, just noticed it through API diffs https://developer.apple.com/library/prerelease/ios/releasenotes/General/iOS90APIDiffs/Swift/Foundation.html

Also fixed a strange issue/bug with a test. Compiler would crash out with the log statement inlined.