### PR TITLE
Bug fix : Remove test target from run phase to avoid XCTest requirement

### DIFF
--- a/XCGLogger/Library/XCGLogger.xcodeproj/xcshareddata/xcschemes/XCGLogger (iOS).xcscheme
+++ b/XCGLogger/Library/XCGLogger.xcodeproj/xcshareddata/xcschemes/XCGLogger (iOS).xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "55E3EE4F19D76F280068C3A7"

--- a/XCGLogger/Library/XCGLogger.xcodeproj/xcshareddata/xcschemes/XCGLoggerTests (OS X).xcscheme
+++ b/XCGLogger/Library/XCGLogger.xcodeproj/xcshareddata/xcschemes/XCGLoggerTests (OS X).xcscheme
@@ -8,10 +8,10 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "55BB1EF51B79DC7500709779"
@@ -61,15 +61,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "55BB1EF51B79DC7500709779"
-            BuildableName = "XCGLoggerTests (OS X).xctest"
-            BlueprintName = "XCGLoggerTests (OS X)"
-            ReferencedContainer = "container:XCGLogger.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -79,15 +70,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "55BB1EF51B79DC7500709779"
-            BuildableName = "XCGLoggerTests (OS X).xctest"
-            BlueprintName = "XCGLoggerTests (OS X)"
-            ReferencedContainer = "container:XCGLogger.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/XCGLogger/Library/XCGLogger.xcodeproj/xcshareddata/xcschemes/XCGLoggerTests (iOS).xcscheme
+++ b/XCGLogger/Library/XCGLogger.xcodeproj/xcshareddata/xcschemes/XCGLoggerTests (iOS).xcscheme
@@ -8,10 +8,10 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "55E3EE4F19D76F280068C3A7"
@@ -39,6 +39,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "55E3EE4F19D76F280068C3A7"
+            BuildableName = "XCGLoggerTests (iOS).xctest"
+            BlueprintName = "XCGLoggerTests (iOS)"
+            ReferencedContainer = "container:XCGLogger.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -52,15 +61,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "55E3EE4F19D76F280068C3A7"
-            BuildableName = "XCGLoggerTests (iOS).xctest"
-            BlueprintName = "XCGLoggerTests (iOS)"
-            ReferencedContainer = "container:XCGLogger.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -70,15 +70,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "55E3EE4F19D76F280068C3A7"
-            BuildableName = "XCGLoggerTests (iOS).xctest"
-            BlueprintName = "XCGLoggerTests (iOS)"
-            ReferencedContainer = "container:XCGLogger.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
This is a small bug that caused me a lot of trouble
When i tried to use XCGLogger in an embedded library of my project whenever i tried to build my project, it threw me an error telling me that it couldn't find XCTest for my platform.
After some tests it appears that removing the build target from the run phase in the schemes resolve the issue.