### PR TITLE
Support named dispatch_queue and NSOperationQueue threads.

### DIFF
--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -104,7 +104,7 @@ public class XCGBaseLogDestination: XCGLogDestinationProtocol, CustomDebugString
                 if let threadName = NSThread.currentThread().name where threadName != "" {
                     extendedDetails += "[" + threadName + "] "
                 }
-                else if let queueName = String(UTF8String: dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)) where queueName != "" {
+                else if let queueName = String(UTF8String: dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)) where !queueName.isEmpty {
                     extendedDetails += "[" + queueName + "] "
                 }
                 else {

--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -104,6 +104,9 @@ public class XCGBaseLogDestination: XCGLogDestinationProtocol, CustomDebugString
                 if let threadName = NSThread.currentThread().name where threadName != "" {
                     extendedDetails += "[" + threadName + "] "
                 }
+                else if let queueName = String(UTF8String: dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)) where queueName != "" {
+                    extendedDetails += "[" + queueName + "] "
+                }
                 else {
                     extendedDetails += "[" + String(format:"%p", NSThread.currentThread()) + "] "
                 }


### PR DESCRIPTION
If current thread has no name, try to get the name of the current queue before defaulting to the threads memory address.  This allows named NSOperationQueue and disaptch_queue to be properly labeled.