### PR TITLE
add default empty string in `verbose` and `debug` functions to allow for `log.debug()` syntax.

### DIFF
--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -123,8 +123,11 @@ public class XCGBaseLogDestination: XCGLogDestinationProtocol, CustomDebugString
         if showFunctionName {
             extendedDetails += "\(logDetails.functionName) "
         }
-
-        output(logDetails, text: "\(extendedDetails)> \(logDetails.logMessage)")
+        if logDetails.logMessage == "" {
+            output(logDetails, text: "\(extendedDetails)")
+        } else {
+            output(logDetails, text: "\(extendedDetails)> \(logDetails.logMessage)")
+        }
     }
 
     public func processInternalLogDetails(logDetails: XCGLogDetails) {
@@ -666,7 +669,7 @@ public class XCGLogger: CustomDebugStringConvertible {
 
     // MARK: - Convenience logging methods
     // MARK: * Verbose
-    public class func verbose(@autoclosure closure: () -> String?, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+    public class func verbose(@autoclosure closure: () -> String? = "", functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.defaultInstance().logln(.Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
@@ -674,7 +677,7 @@ public class XCGLogger: CustomDebugStringConvertible {
         self.defaultInstance().logln(.Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    public func verbose(@autoclosure closure: () -> String?, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+    public func verbose(@autoclosure closure: () -> String? = "", functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.logln(.Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
@@ -683,7 +686,7 @@ public class XCGLogger: CustomDebugStringConvertible {
     }
 
     // MARK: * Debug
-    public class func debug(@autoclosure closure: () -> String?, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+    public class func debug(@autoclosure closure: () -> String? = "", functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.defaultInstance().logln(.Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
@@ -691,7 +694,7 @@ public class XCGLogger: CustomDebugStringConvertible {
         self.defaultInstance().logln(.Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    public func debug(@autoclosure closure: () -> String?, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+    public func debug(@autoclosure closure: () -> String? = "", functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.logln(.Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 

--- a/XCGLogger/Library/XCGLogger/XCGLogger.swift
+++ b/XCGLogger/Library/XCGLogger/XCGLogger.swift
@@ -703,7 +703,7 @@ public class XCGLogger: CustomDebugStringConvertible {
     }
 
     // MARK: * Info
-    public class func info(@autoclosure closure: () -> String?, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+    public class func info(@autoclosure closure: () -> String? = "", functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.defaultInstance().logln(.Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
@@ -711,7 +711,7 @@ public class XCGLogger: CustomDebugStringConvertible {
         self.defaultInstance().logln(.Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    public func info(@autoclosure closure: () -> String?, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
+    public func info(@autoclosure closure: () -> String? = "", functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         self.logln(.Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 

--- a/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
+++ b/XCGLogger/Library/XCGLoggerTests/XCGLoggerTests.swift
@@ -234,4 +234,30 @@ class XCGLoggerTests: XCTestCase {
         XCTAssertEqual(log.dateFormatter!.dateFormat, dateFormat, "Fail: date format doesn't match our custom date format")
         XCTAssert(defaultDateFormatter != dateFormatter, "Fail: Did not assign a custom date formatter")
     }
+    
+    class TestStringArrayDestination : XCGBaseLogDestination {
+        var outputStrs : [String] = [] 
+        override func output(logDetails: XCGLogDetails, text: String) {
+            outputStrs.append(text)
+        }
+    }
+       
+    func testDefaultEmptyStringInVerboseDebugAndInfo() {
+        let log = XCGLogger()
+        log.outputLogLevel = .Verbose
+        let testStringArrayDestination = 
+            TestStringArrayDestination(
+                owner: log, 
+                identifier: "com.cerebralgardens.xcglogger.testStringArrayDestination" )
+                
+        testStringArrayDestination.outputLogLevel = .Verbose
+        log.addLogDestination(testStringArrayDestination)
+        
+        log.verbose()
+        XCTAssert(testStringArrayDestination.outputStrs.count == 1)
+        log.debug()
+        XCTAssert(testStringArrayDestination.outputStrs.count == 2)
+        log.info()
+        XCTAssert(testStringArrayDestination.outputStrs.count == 3)
+    }
 }


### PR DESCRIPTION
this deals with #118 

I've not implemented the default for `warning`, `error` etc.