### PR TITLE
Added auto log rotation.

### DIFF
--- a/Sources/XCGLogger/Destinations/FileDestination.swift
+++ b/Sources/XCGLogger/Destinations/FileDestination.swift
@@ -10,11 +10,43 @@
 // MARK: - FileDestination
 /// A standard destination that outputs log details to a file
 open class FileDestination: BaseDestination {
-    // MARK: - Properties
+
+    public enum Rotation {
+      case none
+      case atAppStart
+      case whileWriting
+
+      public var description: String {
+        switch self {
+        case .none:
+          return "None"
+        case .atAppStart:
+          return "AtAppStartOnly"
+        case .whileWriting:
+          return "AlsoWhileWriting"
+        }
+      }
+    }
+
+    // MARK: - User accessible properties
+
+    open var rotation = Rotation.none
+    open var rotationFileSizeBytes = 1024 * 1024  // 1M
+    open var rotationFilesMax = 1
+    open var rotationFileDateFormat = "-yyyy-MM-dd'T'HH:mm"
+    open var rotationFileHasSuffix = true
+
     /// Logger that owns the destination object
     open override var owner: XCGLogger? {
         didSet {
             if owner != nil {
+                let path = writeToFileURL!.path
+                let indexAfterSlash = path.range(of: "/", options: .backwards)!.upperBound
+                logFileDirectory = path.substring(to: indexAfterSlash)
+
+                if self.rotation != .none {
+                    self.rotateFileAuto()
+                }
                 openFile()
             }
             else {
@@ -28,13 +60,16 @@ open class FileDestination: BaseDestination {
 
     /// FileURL of the file to log to
     open var writeToFileURL: URL? = nil {
-        didSet {
+        didSet {  // Note: will not be called (See https://bugs.swift.org/browse/SR-1118)
             openFile()
         }
     }
 
     /// File handle for the log file
     internal var logFileHandle: FileHandle? = nil
+
+    /// Log file directory
+    private var logFileDirectory: String? = nil  // including trailing "/"
 
     /// Option: whether or not to append to the log file if it already exists
     internal var shouldAppend: Bool
@@ -170,6 +205,7 @@ open class FileDestination: BaseDestination {
                 try fileManager.moveItem(atPath: writeToFileURL.path, toPath: archiveToFileURL.path)
             }
             catch let error as NSError {
+                rotationFailedBefore = true
                 openFile()
                 owner?._logln("Unable to rotate file \(writeToFileURL.path) to \(archiveToFileURL.path): \(error.localizedDescription)", level: .error)
                 return false
@@ -213,6 +249,9 @@ open class FileDestination: BaseDestination {
                     self.owner?._logln("Objective-C Exception occurred: \(exception)", level: .error)
                 })
             }
+
+            guard self.rotation == .whileWriting else {return}
+            self.rotateFileAuto()
         }
         
         if let logQueue = logQueue {
@@ -221,5 +260,128 @@ open class FileDestination: BaseDestination {
         else {
             outputClosure()
         }
+    }
+
+    /// private properties for log rotation
+    private var rotationFailedBefore = false
+    private var rotateAutoCalledBefore = false
+    private var logFileBaseName = ""
+    private var logFileSuffix = ""  // including leading "." if there is suffix
+
+    /// Rotate log file if it has exceeded the file size limit
+    ///
+    /// - Parameters:  None
+    ///
+    /// - Returns:  Nothing
+    ///
+    func rotateFileAuto() {
+      let fileManager = FileManager.default
+      let path = writeToFileURL!.path
+
+      // prepare parts of rotation file name for future use
+      if (!rotateAutoCalledBefore) {
+        let indexAfterSlash = path.range(of: "/", options: .backwards)!.upperBound
+        let fileName = path.substring(from: indexAfterSlash)
+
+        logFileBaseName = fileName
+        logFileSuffix = ""
+
+        // if there is a "." in file name and the file does use suffix
+        if let dotRange = fileName.range(of: ".", options: .backwards),
+          rotationFileHasSuffix {
+          logFileBaseName = fileName.substring(to: dotRange.lowerBound)
+          logFileSuffix = fileName.substring(from: dotRange.lowerBound)
+        }
+        rotateAutoCalledBefore = true
+      }
+
+      guard !rotationFailedBefore else {return}  // having seen failure before
+      guard fileManager.fileExists(atPath: path) else {return}
+      var action = ""  // for the catch clause to report error
+
+      do {
+        // quit if log file is not large enough yet
+        action = "get attributes of " + path
+        let fileAttr = try fileManager.attributesOfItem(atPath: path)
+        let fileSize = fileAttr[FileAttributeKey.size] as! NSNumber
+        guard fileSize.intValue > rotationFileSizeBytes else {return}
+
+        // form rotation file name
+        let formatter = DateFormatter()
+        formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX") as Locale!
+        formatter.dateFormat = rotationFileDateFormat
+        let dateString = formatter.string(from: Date())
+        let rotationFilePath = logFileDirectory! + logFileBaseName + dateString + logFileSuffix
+
+        // actually rotate
+        let ret = rotateFile(to: rotationFilePath)
+        guard ret else {return}  // no new file => no need to delete old ones
+
+        // rotation successful.  delete older files
+        let filesToDelete = logFilesNewestFirst().suffix(from: rotationFilesMax + 1)
+        for f in filesToDelete {
+          action = "delete " + f
+          try fileManager.removeItem(atPath: f)
+        }
+      } catch let error as NSError {
+        owner?._logln("Failed to \(action): \(error.localizedDescription)", level: .error)
+        return
+      }
+    }
+
+    /// Return all log files, sorted, newest first
+    ///
+    /// - Parameters:  None
+    ///
+    /// - Returns:  Array of log files, sorted
+    ///
+    private func logFilesNewestFirst() -> [String] {
+      var sortedFiles = [String]()
+      var action = ""
+
+      do {
+        let fileManager = FileManager.default
+
+        // assemble a dictionary of date:file
+        var fileDateMap = [NSDate: String]()
+        let iter = fileManager.enumerator(atPath: logFileDirectory!)
+        while let element = iter?.nextObject() as? String {
+          let filePath = logFileDirectory! + element
+          action = "get attributes of " + filePath
+          let fileAttr = try fileManager.attributesOfItem(atPath: filePath)
+          let creationDate = fileAttr[FileAttributeKey.creationDate] as! NSDate
+          fileDateMap[creationDate] = filePath
+        }
+
+        // sort the dates in the dictionary, newest first
+        let compareDates: (NSDate, NSDate) -> Bool = {
+          return $0.compare($1 as Date) == ComparisonResult.orderedDescending
+        }
+        let sortedDates = Array(fileDateMap.keys).sorted(by: compareDates)
+
+        // assemble array of files using sorted dates
+        for key in sortedDates {
+           sortedFiles.append(fileDateMap[key]!)
+        }
+        return sortedFiles
+
+      } catch let error as NSError {
+        owner?._logln("Failed to \(action): \(error.localizedDescription)", level: .error)
+        return []
+      }
+    }
+
+    /// Return given number of most recent log files, newest first
+    ///
+    /// - Parameters: number of files to be returned
+    ///
+    /// - Returns: Array of log file URLs, sorted
+    ///
+    func mostRecentLogFiles(numFiles: Int) -> [URL] {
+      var URLs = [URL]()
+      for f in logFilesNewestFirst().prefix(upTo: numFiles) {
+        URLs.append(URL(fileURLWithPath: f))
+      }
+      return URLs
     }
 }

--- a/Sources/XCGLogger/Destinations/FileDestination.swift
+++ b/Sources/XCGLogger/Destinations/FileDestination.swift
@@ -383,7 +383,7 @@ open class FileDestination: BaseDestination {
     ///
     /// - Returns: Array of log file URLs, sorted
     ///
-    func mostRecentLogFiles(numFiles: Int) -> [URL] {
+    open func mostRecentLogFiles(numFiles: Int) -> [URL] {
       var URLs = [URL]()
       var counter = 0
       for f in logFilesNewestFirst() {

--- a/Sources/XCGLogger/XCGLogger.swift
+++ b/Sources/XCGLogger/XCGLogger.swift
@@ -1119,6 +1119,12 @@ open class XCGLogger: CustomDebugStringConvertible {
 
         destination.owner = self
         destinations.append(destination)
+
+        // save file destination for func mostRecentLogFiles()
+        if (destination is FileDestination) {
+          fileDestination = destination as? FileDestination
+        }
+
         return true
     }
 
@@ -1206,6 +1212,20 @@ open class XCGLogger: CustomDebugStringConvertible {
 
             return description
         }
+    }
+
+    // store file destination, if any, for func mostRecentLogFiles()
+    private var fileDestination: FileDestination?
+
+    /// Return given number of most recent log files, newest first
+    ///
+    /// - Parameters: number of files to be returned
+    ///
+    /// - Returns: Array of log file URLs, sorted
+    ///
+    open func mostRecentLogFiles(numFiles: Int) -> [URL] {
+      guard let _ = fileDestination else {return []}
+      return fileDestination!.mostRecentLogFiles(numFiles: numFiles)
     }
 }
 

--- a/Sources/XCGLoggerTests/XCGLoggerTests.swift
+++ b/Sources/XCGLoggerTests/XCGLoggerTests.swift
@@ -430,7 +430,7 @@ class XCGLoggerTests: XCTestCase {
         let intName: String = extractTypeName(4)
 
         let optionalString: String? = nil
-        let optionalName: String = extractTypeName(optionalString)
+        let optionalName: String = extractTypeName(optionalString ?? "")
 
         log.debug("className: \(className)")
         log.debug("stringName: \(stringName)")
@@ -440,7 +440,7 @@ class XCGLoggerTests: XCTestCase {
         XCTAssert(className == "XCGLogger", "Fail: Didn't extract the correct class name")
         XCTAssert(stringName == "String", "Fail: Didn't extract the correct class name")
         XCTAssert(intName == "Int", "Fail: Didn't extract the correct class name")
-        XCTAssert(optionalName == "Optional<String>", "Fail: Didn't extract the correct class name")
+        XCTAssert(optionalName == "String", "Fail: Didn't extract the correct class name")
     }
 
     func test_00160_TestLogFormattersAreApplied() {

--- a/Sources/XCGLoggerTests/XCGLoggerTests.swift
+++ b/Sources/XCGLoggerTests/XCGLoggerTests.swift
@@ -867,6 +867,125 @@ class XCGLoggerTests: XCTestCase {
         XCTAssert(testDestination.numberOfUnexpectedLogMessages == 0, "Fail: Received an unexpected log line")
     }
 
+    // please fix the test name.
+    // I don't know the meaning of the 5-digit test number :(
+    func test_xxxxx_AutoLogRotation() {
+      let documentsDirectory: URL = {
+        let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        return urls[urls.endIndex - 1]
+      }()
+      let fileManager = FileManager.default
+
+      let log: XCGLogger = XCGLogger(identifier: functionIdentifier())
+
+      let logDir = documentsDirectory.appendingPathComponent("logs")
+      if !FileManager.default.fileExists(atPath: logDir.path) {
+        do {
+          try FileManager.default.createDirectory(atPath: logDir.path, withIntermediateDirectories: false, attributes: nil)
+        } catch let error as NSError {
+          print(error.localizedDescription);
+        }
+      }
+
+      var currentLogFiles = [URL]()
+
+      // create a file destination, add logs until rotation happends.
+      // keep doing so until rotation file pronning happens
+      while true {
+        print("===== create file destination")
+
+        let logPath = logDir.appendingPathComponent("XCGLogger-log.txt")
+        let fileDestination = FileDestination(writeToFile: logPath,
+                                              identifier:   "advancedLogger.fileDestination",
+                                              shouldAppend: true,
+                                              appendMarker: "-- App restarted --")
+
+        // Optionally set some configuration options
+        fileDestination.outputLevel = .debug
+        fileDestination.showLogIdentifier = false
+        fileDestination.showFunctionName = true
+        fileDestination.showThreadName = true
+        fileDestination.showLevel = true
+        fileDestination.showFileName = true
+        fileDestination.showLineNumber = true
+
+        fileDestination.showDate = true
+
+        // experiment with log rotation
+
+        let random = arc4random_uniform(2)
+        fileDestination.rotation = (random == 0) ? .onlyAtAppStart : .alsoWhileWriting
+        fileDestination.rotationFileSizeBytes = 1024
+        fileDestination.rotationFilesMax = 3
+        fileDestination.rotationFileDateFormat = "-yyyy-MM-dd'T'HH:mm:ss:SSS"
+
+        // Process this destination in the background
+        fileDestination.logQueue = XCGLogger.logQueue
+
+        XCTAssert(fileDestination.owner == nil, "Fail: newly created FileDestination has an owner set when it should be nil")
+        XCTAssert(fileDestination.logFileHandle == nil, "Fail: FileDestination has opened a file before it was assigned to a logger")
+
+        print("===== add file destination")
+
+        // Add the destination to the logger
+        log.add(destination: fileDestination)
+
+        XCTAssert(fileDestination.owner === log, "Fail: file destination did not have the correct owner set")
+        XCTAssert(fileDestination.logFileHandle != nil, "Fail: FileDestination been assigned to a logger, but no file has been opened")
+
+        // Add basic app info, version info etc, to the start of the logs
+        log.logAppDetails()
+
+        /* fill log file faster.  With 1K log file max size, it's not needed
+        for i in 0...5 {
+          log.debug("\(i) a very very very very very very very very very long string to fill the log")
+        }
+        */
+
+        let logFiles = log.mostRecentLogFiles(numFiles: 100)  // round up all files
+
+        let logFileSubset = log.mostRecentLogFiles(numFiles: 2)
+        XCTAssert(logFileSubset.count <= 2, "Fail: too many files are returned")
+
+        print("===== remove file destination")
+
+        log.remove(destination: fileDestination)
+
+        XCTAssert(fileDestination.owner == nil, "Fail: newly created FileDestination has an owner set when it should be nil")
+        XCTAssert(fileDestination.logFileHandle == nil, "Fail: FileDestination has opened a file before it was assigned to a logger")
+
+        // determine when the test stops.  If the number of log files is going
+        // up, then pruning hasn't happened yet.  If the set of log files stays
+        // unchanged, then pruning hasn't happened in the last loop.  Otherwise
+        // pruning has happened and we quit the loop.
+        guard (logFiles.count != currentLogFiles.count || logFiles == currentLogFiles) else {
+          currentLogFiles = logFiles
+          break
+        }
+        currentLogFiles = logFiles
+
+        for f in currentLogFiles {
+          print("===== current log file", f)
+        }
+
+        print("===== dividing line between file destination add/remove loops =====")
+
+        // add no more than 1 log file each second because the creationDate
+        // returned by apple is very coarse, not finer than a second.
+        sleep(1)
+      }
+
+      // clean up
+      for f in currentLogFiles {
+        do {
+          try fileManager.removeItem(atPath: f.path)
+          print("===== clean up -- delete", f)
+        } catch {
+          print("===== failed to delete", f)
+        }
+      }
+    }
+
     // Performance Testing
     //    func test_80000_BasicPerformanceTest() {
     //        let log: XCGLogger = XCGLogger(identifier: functionIdentifier(), includeDefaultDestinations: false)


### PR DESCRIPTION
To address issue #66 I have added two features: auto log rotation and function mostRecentLogFiles().  The following outlines their usage.

The following properties of FileDestination are used to configure auto log rotation:

```
open var rotation = Rotation.none
open var rotationFileSizeBytes = 1024 * 1024  // 1M
open var rotationFilesMax = 1
open var rotationFileDateFormat = "-yyyy-MM-dd'T'HH:mm"
open var rotationFileHasSuffix = true
```

Auto log rotation occurs when the log file size exceeds rotationFileSizeBytes.  Log rotation can happen at the start time of the app (Rotation.onlyAtAppStart) or at every write (Rotation.alsoWhileWriting).  It is strongly advised that asynchronous logging (log queue) is used with .alsoWhileWriting. 

The rotation files are placed in the same directory of the log file.  When the number of rotation files exceeds rotationFileMax, the older files are deleted.   It is strongly advised that a designated directory is created for the log file and its rotations.

The rotation files are named as <log file base>-yyyy-MM-ddTHH:mm.<suffix>, if a suffix, such as .txt is found in the log file name.  If the log file name includes "."(dot) but no suffix, rotationFileHasSuffix should be set to false.

A new function mostRecentLogFiles is added to return specific number of the newest log files.  As an example, this function can be used to send the most recent log files to the developer.  The same named function is also available via the XCGLogger object.

Please feel free to make changes, especially styling changes to fit in. For the testing case added, I can't figure out how to make the 5-digit test number. So I just used xxxxx.
