### PR TITLE
LogFolderDestination for autorotating log files

### DIFF
--- a/Sources/XCGLogger.xcodeproj/project.pbxproj
+++ b/Sources/XCGLogger.xcodeproj/project.pbxproj
@@ -103,6 +103,10 @@
 		55E3EE5119D76F280068C3A7 /* XCGLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55E3EE4519D76F280068C3A7 /* XCGLogger.framework */; };
 		55E3EE5819D76F280068C3A7 /* XCGLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E3EE5719D76F280068C3A7 /* XCGLoggerTests.swift */; };
 		70CB94181B99E728007802FF /* XCGLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554DF40F19D76FA9005708BE /* XCGLogger.swift */; };
+		82A828611E2EA14C0048F596 /* LogFolderDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A828601E2EA14C0048F596 /* LogFolderDestination.swift */; };
+		82A828621E2EA14C0048F596 /* LogFolderDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A828601E2EA14C0048F596 /* LogFolderDestination.swift */; };
+		82A828631E2EA14C0048F596 /* LogFolderDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A828601E2EA14C0048F596 /* LogFolderDestination.swift */; };
+		82A828641E2EA14C0048F596 /* LogFolderDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A828601E2EA14C0048F596 /* LogFolderDestination.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -172,6 +176,7 @@
 		55E3EE5619D76F280068C3A7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55E3EE5719D76F280068C3A7 /* XCGLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCGLoggerTests.swift; sourceTree = "<group>"; };
 		70CB94201B99E728007802FF /* XCGLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCGLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		82A828601E2EA14C0048F596 /* LogFolderDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogFolderDestination.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -246,6 +251,7 @@
 				5501A38D1D76250600CB8ABE /* ConsoleDestination.swift */,
 				5501A3921D76251600CB8ABE /* AppleSystemLogDestination.swift */,
 				5501A3971D76256500CB8ABE /* FileDestination.swift */,
+				82A828601E2EA14C0048F596 /* LogFolderDestination.swift */,
 				5501A39C1D76258600CB8ABE /* TestDestination.swift */,
 			);
 			path = Destinations;
@@ -724,6 +730,7 @@
 				5501A3BD1D762E1B00CB8ABE /* LogDetails.swift in Sources */,
 				5501A3F31D77506F00CB8ABE /* XcodeColorsLogFormatter.swift in Sources */,
 				5501A3B81D762DD500CB8ABE /* HelperFunctions.swift in Sources */,
+				82A828641E2EA14C0048F596 /* LogFolderDestination.swift in Sources */,
 				55A4B4F61D7AB0980006463B /* DevFilter.swift in Sources */,
 				5501A3961D76251600CB8ABE /* AppleSystemLogDestination.swift in Sources */,
 				55C4DD5F1D781D850074C21F /* Base64LogFormatter.swift in Sources */,
@@ -752,6 +759,7 @@
 				5501A3BB1D762E1B00CB8ABE /* LogDetails.swift in Sources */,
 				5501A3F11D77506F00CB8ABE /* XcodeColorsLogFormatter.swift in Sources */,
 				5501A3B61D762DD500CB8ABE /* HelperFunctions.swift in Sources */,
+				82A828621E2EA14C0048F596 /* LogFolderDestination.swift in Sources */,
 				55A4B4F41D7AB0980006463B /* DevFilter.swift in Sources */,
 				5501A3941D76251600CB8ABE /* AppleSystemLogDestination.swift in Sources */,
 				55C4DD5D1D781D850074C21F /* Base64LogFormatter.swift in Sources */,
@@ -804,6 +812,7 @@
 				5501A3BA1D762E1B00CB8ABE /* LogDetails.swift in Sources */,
 				5501A3F01D77506F00CB8ABE /* XcodeColorsLogFormatter.swift in Sources */,
 				5501A3B51D762DD500CB8ABE /* HelperFunctions.swift in Sources */,
+				82A828611E2EA14C0048F596 /* LogFolderDestination.swift in Sources */,
 				55A4B4F31D7AB0980006463B /* DevFilter.swift in Sources */,
 				5501A3931D76251600CB8ABE /* AppleSystemLogDestination.swift in Sources */,
 				55C4DD5C1D781D850074C21F /* Base64LogFormatter.swift in Sources */,
@@ -840,6 +849,7 @@
 				5501A3BC1D762E1B00CB8ABE /* LogDetails.swift in Sources */,
 				5501A3F21D77506F00CB8ABE /* XcodeColorsLogFormatter.swift in Sources */,
 				5501A3B71D762DD500CB8ABE /* HelperFunctions.swift in Sources */,
+				82A828631E2EA14C0048F596 /* LogFolderDestination.swift in Sources */,
 				55A4B4F51D7AB0980006463B /* DevFilter.swift in Sources */,
 				5501A3951D76251600CB8ABE /* AppleSystemLogDestination.swift in Sources */,
 				55C4DD5E1D781D850074C21F /* Base64LogFormatter.swift in Sources */,

--- a/Sources/XCGLogger/Destinations/AppleSystemLogDestination.swift
+++ b/Sources/XCGLogger/Destinations/AppleSystemLogDestination.swift
@@ -11,9 +11,6 @@
 /// A standard destination that outputs log details to the Apple System Log using NSLog instead of print
 open class AppleSystemLogDestination: BaseDestination {
     // MARK: - Properties
-    /// The dispatch queue to process the log on
-    open var logQueue: DispatchQueue? = nil
-
     /// Option: whether or not to output the date the log was created (Always false for this destination)
     open override var showDate: Bool {
         get {
@@ -28,32 +25,11 @@ open class AppleSystemLogDestination: BaseDestination {
     /// Print the log to the Apple System Log facility (using NSLog).
     ///
     /// - Parameters:
-    ///     - logDetails:   The log details.
     ///     - message:   Formatted/processed message ready for output.
     ///
     /// - Returns:  Nothing
     ///
-    open override func output(logDetails: LogDetails, message: String) {
-
-        let outputClosure = {
-            var logDetails = logDetails
-            var message = message
-
-            // Apply filters, if any indicate we should drop the message, we abort before doing the actual logging
-            if self.shouldExclude(logDetails: &logDetails, message: &message) {
-                return
-            }
-
-            self.applyFormatters(logDetails: &logDetails, message: &message)
-
-            NSLog("%@", message)
-        }
-
-        if let logQueue = logQueue {
-            logQueue.async(execute: outputClosure)
-        }
-        else {
-            outputClosure()
-        }
+    open override func write(message: String) {
+        NSLog("%@", message)
     }
 }

--- a/Sources/XCGLogger/Destinations/BaseDestination.swift
+++ b/Sources/XCGLogger/Destinations/BaseDestination.swift
@@ -17,6 +17,9 @@ open class BaseDestination: DestinationProtocol, CustomDebugStringConvertible {
     /// Identifier for the destination (should be unique)
     open var identifier: String
 
+    /// The dispatch queue to process the log on
+    open var logQueue: DispatchQueue? = nil
+
     /// Log level for this destination
     open var outputLevel: XCGLogger.Level = .debug
 
@@ -164,16 +167,45 @@ open class BaseDestination: DestinationProtocol, CustomDebugStringConvertible {
     }
 
     // MARK: - Methods that must be overriden in subclasses
-    /// Output the log to the destination.
+    /// Apply filters and formatters to the message before queuing it to be written by the write method.
     ///
     /// - Parameters:
     ///     - logDetails:   The log details.
-    ///     - message:   Formatted/processed message ready for output.
+    ///     - message:   Message ready to be formatted for output.
     ///
     /// - Returns:  Nothing
     ///
     open func output(logDetails: LogDetails, message: String) {
-        // Do something with the text in an overridden version of this method
-        precondition(false, "Must override this")
+      let outputClosure = {
+        var logDetails = logDetails
+        var message = message
+
+        // Apply filters, if any indicate we should drop the message, we abort before doing the actual logging
+        if self.shouldExclude(logDetails: &logDetails, message: &message) {
+          return
+        }
+
+        self.applyFormatters(logDetails: &logDetails, message: &message)
+        self.write(message: message)
+      }
+
+      if let logQueue = logQueue {
+        logQueue.async(execute: outputClosure)
+      }
+      else {
+        outputClosure()
+      }
+    }
+
+    /// Write the log message to the destination.
+    ///
+    /// - Parameters:
+    ///     - message:   Formatted/processed message ready for output.
+    ///
+    /// - Returns:  Nothing
+    ///
+    open func write(message: String) {
+      // Do something with the message in an overridden version of this method
+      precondition(false, "Must override this")
     }
 }

--- a/Sources/XCGLogger/Destinations/ConsoleDestination.swift
+++ b/Sources/XCGLogger/Destinations/ConsoleDestination.swift
@@ -10,40 +10,15 @@
 // MARK: - ConsoleDestination
 /// A standard destination that outputs log details to the console
 open class ConsoleDestination: BaseDestination {
-    // MARK: - Properties
-    /// The dispatch queue to process the log on
-    open var logQueue: DispatchQueue? = nil
-
     // MARK: - Overridden Methods
     /// Print the log to the console.
     ///
     /// - Parameters:
-    ///     - logDetails:   The log details.
     ///     - message:   Formatted/processed message ready for output.
     ///
     /// - Returns:  Nothing
     ///
-    open override func output(logDetails: LogDetails, message: String) {
-
-        let outputClosure = {
-            var logDetails = logDetails
-            var message = message
-
-            // Apply filters, if any indicate we should drop the message, we abort before doing the actual logging
-            if self.shouldExclude(logDetails: &logDetails, message: &message) {
-                return
-            }
-
-            self.applyFormatters(logDetails: &logDetails, message: &message)
-
-            print(message)
-        }
-
-        if let logQueue = logQueue {
-            logQueue.async(execute: outputClosure)
-        }
-        else {
-            outputClosure()
-        }
+    open override func write(message: String) {
+        print(message)
     }
 }

--- a/Sources/XCGLogger/Destinations/FileDestination.swift
+++ b/Sources/XCGLogger/Destinations/FileDestination.swift
@@ -40,18 +40,15 @@ open class FileDestination: BaseDestination {
     internal var appendMarker: String?
 
     // MARK: - Life Cycle
-    public init(owner: XCGLogger? = nil, writeToFile: Any, identifier: String = "", shouldAppend: Bool = false, appendMarker: String? = "-- ** ** ** --") {
+    public init(owner: XCGLogger? = nil, writeToFile: Any?, identifier: String = "", shouldAppend: Bool = false, appendMarker: String? = "-- ** ** ** --") {
         self.shouldAppend = shouldAppend
         self.appendMarker = appendMarker
 
         if writeToFile is NSString {
             writeToFileURL = URL(fileURLWithPath: writeToFile as! String)
         }
-        else if writeToFile is URL {
-            writeToFileURL = writeToFile as? URL
-        }
         else {
-            writeToFileURL = nil
+            writeToFileURL = writeToFile as? URL
         }
 
         super.init(owner: owner, identifier: identifier)
@@ -130,6 +127,25 @@ open class FileDestination: BaseDestination {
     private func closeFile() {
         logFileHandle?.closeFile()
         logFileHandle = nil
+    }
+
+    /// Suspend logging temporarily and execute the provided closure.
+    /// You can use this method to perform operations on the log file without it being locked.
+    ///
+    /// A log queue is required otherwise log messages might slip passed us.
+    ///
+    /// - Parameters:
+    ///     - closure:    The code to execute while the file is accessible.
+    ///
+    /// - Returns:  Nothing
+    ///
+    open func executeWhileSuspended(_ closure: @escaping () -> Void) {
+        precondition(logQueue != nil, "LogQueue should be set")
+
+        logQueue?.async { [weak logFileHandle] in
+            logFileHandle?.synchronizeFile()
+            closure()
+        }
     }
 
     /// Rotate the log file, storing the existing log file in the specified location.

--- a/Sources/XCGLogger/Destinations/LogFolderDestination.swift
+++ b/Sources/XCGLogger/Destinations/LogFolderDestination.swift
@@ -1,0 +1,200 @@
+//
+//  LogFolderDestination.swift
+//  XCGLogger: https://github.com/DaveWoodCom/XCGLogger
+//
+//  Created by Yvo van Beek on 2017-01-17.
+//  Copyright © 2017 Yvo van Beek.
+//  Some rights reserved: https://github.com/DaveWoodCom/XCGLogger/blob/master/LICENSE.txt
+//
+
+// MARK: - LogFolder
+/// A standard destination that outputs log details to files in a log folder
+open class LogFolderDestination: FileDestination {
+    // MARK: - Properties
+    /// Logger that owns the destination object
+    open override var owner: XCGLogger? {
+        willSet { rotateFile() }
+    }
+
+    /// URL of the folder to log to
+    open var writeToFolderURL: URL? = nil {
+        didSet {
+            writeToFolderURL = createLogFolder(url: writeToFolderURL)
+            rotateFile()
+        }
+    }
+
+    /// The details of the last log item that was processed
+    open var lastLogDetails: LogDetails? = nil
+
+    /// Option: the format of the log file name (will be passed to a date formatter)
+    open var logFileFormat = "yyyyMMdd" {
+        didSet { rotateFile() }
+    }
+
+    /// Option: the extension of the log file name (don't include a .)
+    open var logFileExtension = "txt" {
+        didSet { rotateFile() }
+    }
+
+    /// Option: the number of log files to keep
+    open var logFilesToKeep = 10 {
+        didSet { cleanUpLogs() }
+    }
+
+    // MARK: - Class Properties
+    open class var defaultLogFolderURL: URL {
+        let cacheFolderURL =  FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return cacheFolderURL.appendingPathComponent("Logs")
+    }
+
+    // MARK: - Life Cycle
+    public init(owner: XCGLogger? = nil, writeToFolder: Any?, identifier: String = "", appendMarker: String? = nil) {
+        super.init(owner: nil, writeToFile: nil, identifier: identifier, shouldAppend: true, appendMarker: appendMarker)
+
+        var folderURL: URL?
+        if writeToFolder is NSString {
+            folderURL = URL(fileURLWithPath: writeToFolder as! String)
+        }
+        else {
+            folderURL = writeToFolder as? URL
+        }
+
+        defer {
+            // Set the folder URL after init to trigger the didSet
+            writeToFolderURL = folderURL
+            super.owner = owner
+        }
+    }
+
+    public convenience init(identifier: String = "", appendMarker: String? = nil) {
+        let folderURL = type(of: self).defaultLogFolderURL
+        self.init(writeToFolder: folderURL, identifier: identifier, appendMarker: appendMarker)
+    }
+
+    // MARK: - Folder / File Handling Methods
+    /// Create a new log folder.
+    ///
+    /// - Parameters:   Nothing.
+    ///
+    /// - Returns:  The url for the new log file.
+    ///
+    open func createLogFolder(url: URL?) -> URL? {
+        if let folderURL = url {
+            try! FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        }
+
+        return url
+    }
+
+    /// Create a new log file url.
+    ///
+    /// - Parameters:   Nothing.
+    ///
+    /// - Returns:  The url for the new log file.
+    ///
+    open func createLogFile() -> URL? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = logFileFormat
+
+        let fileName = dateFormatter.string(from: Date())
+        return writeToFolderURL?.appendingPathComponent(fileName).appendingPathExtension(logFileExtension)
+    }
+
+    /// Scan the log folder and delete log files that are no longer relevant.
+    ///
+    /// - Parameters:   Nothing.
+    ///
+    /// - Returns:      Nothing.
+    ///
+    open func cleanUpLogs() {
+        // Get the log files and sort them by name descending
+        var fileURLs = logFileURLs()
+        fileURLs.sort(by: { $0.lastPathComponent > $1.lastPathComponent })
+
+        // Do we have more than we want to keep? Remove the rest
+        if fileURLs.count > logFilesToKeep {
+            fileURLs.removeFirst(logFilesToKeep)
+            fileURLs.forEach { try? FileManager.default.removeItem(at: $0) }
+        }
+    }
+
+    /// Get the urls of the log files in the log folder.
+    ///
+    /// - Parameters:
+    ///     - logDetails:   The log details.
+    ///
+    /// - Returns:
+    ///     - true:     The log file should be rotated.
+    ///     - false:    The log file doesn't have to be rotated.
+    ///
+    open func logFileURLs() -> [URL] {
+        guard let folderURL = writeToFolderURL else { return [] }
+        guard let fileUrls = try? FileManager.default.contentsOfDirectory(at: folderURL, includingPropertiesForKeys: []) else { return [] }
+        return fileUrls.filter { $0.pathExtension == logFileExtension }
+    }
+
+    /// Rotate the current log file.
+    ///
+    /// - Parameters:   Nothing.
+    ///
+    /// - Returns:      Nothing.
+    ///
+    open func rotateFile() {
+        if let logFileURL = createLogFile(), logFileURL != writeToFileURL {
+            writeToFileURL = logFileURL
+        }
+    }
+
+    /// Determine if the log file should be rotated.
+    ///
+    /// - Parameters:
+    ///     - logDetails:   The log details.
+    ///
+    /// - Returns:
+    ///     - true:     The log file should be rotated.
+    ///     - false:    The log file doesn't have to be rotated.
+    ///
+    open func shouldRotate(logDetails: LogDetails) -> Bool {
+        guard let lastDetails = lastLogDetails else { return false }
+        return !NSCalendar.current.isDate(lastDetails.date, inSameDayAs: logDetails.date)
+    }
+
+    // MARK: - Overridden Methods
+    /// Apply filters and formatters to the message before queuing it to be written by the write method.
+    ///
+    /// - Parameters:
+    ///     - logDetails:   The log details.
+    ///     - message:   Message ready to be formatted for output.
+    ///
+    /// - Returns:  Nothing
+    ///
+    override open func output(logDetails: LogDetails, message: String) {
+        let rotate = shouldRotate(logDetails: logDetails)
+        lastLogDetails = logDetails
+
+        if rotate {
+            rotateFile()
+        }
+
+        super.output(logDetails: logDetails, message: message)
+    }
+
+    /// Rotate the log file, storing the existing log file in the specified location.
+    ///
+    /// - Parameters:
+    ///     - archiveToFile:    FileURL or path (as String) to where the existing log file should be rotated to.
+    ///
+    /// - Returns:
+    ///     - true:     Log file rotated successfully.
+    ///     - false:    Error rotating the log file.
+    ///
+    @discardableResult override open func rotateFile(to archiveToFile: Any) -> Bool {
+        DispatchQueue.global().async { [weak self] in
+            self?.cleanUpLogs()
+        }
+        
+        return super.rotateFile(to: archiveToFile)
+    }
+}

--- a/Sources/XCGLogger/Destinations/TestDestination.swift
+++ b/Sources/XCGLogger/Destinations/TestDestination.swift
@@ -11,9 +11,6 @@
 /// A destination for testing, preload it with the expected logs, send your logs, then check for success
 open class TestDestination: BaseDestination {
     // MARK: - Properties
-    /// The dispatch queue to process the log on
-    open var logQueue: DispatchQueue? = nil
-
     /// Array of all expected log messages
     open var expectedLogMessages: [String] = []
 


### PR DESCRIPTION
I've created a new destination, the LogFolderDestination.

With the LogFolderDestination you can supply a folder where the log files should be stored. If you don't supply one it will automatically create a Logs folder in the Caches folder (similar to CocoaLumberJack).

My first commit removes a bit of duplicate code in the destinations. It moves the logQueue to the BaseDestination and adds a write method (which can be overridden) that does the actual log writing. It shouldn't break any existing implementations and makes creating custom destinations a bit easier.

I've also added two tests. One that tests the file rotation, the other one tests the clean up of old log files.

@DaveWoodCom I hope that I've kept the coding style as close to yours as possible.

@xyzisinus My requirements for the log folder were a bit different from your implementation. I've added quite a few overridable methods in the LogFolderDestination so that rolling by file size or other conditions should be quite easy to add.

I'm eager to hear what you guys think, feedback is well appreciated.