### PR TITLE
Remove @discardableResult from functions with void return

### DIFF
--- a/Sources/XCGLogger/Filters/FileNameFilter.swift
+++ b/Sources/XCGLogger/Filters/FileNameFilter.swift
@@ -68,7 +68,7 @@ open class FileNameFilter: FilterProtocol {
     ///
     /// - Returns:          Nothing
     ///
-    @discardableResult open func add<S: Sequence>(fileNames: S) where S.Iterator.Element == String {
+    open func add<S: Sequence>(fileNames: S) where S.Iterator.Element == String {
         for fileName in fileNames {
             add(fileName: fileName)
         }

--- a/Sources/XCGLogger/Filters/UserInfoFilter.swift
+++ b/Sources/XCGLogger/Filters/UserInfoFilter.swift
@@ -68,7 +68,7 @@ open class UserInfoFilter: FilterProtocol {
     ///
     /// - Returns:      Nothing
     ///
-    @discardableResult open func add<S: Sequence>(items: S) where S.Iterator.Element == String {
+    open func add<S: Sequence>(items: S) where S.Iterator.Element == String {
         for item in items {
             add(item: item)
         }


### PR DESCRIPTION
Xcode 8.3 add a warning when `@discardableResult` is used on functions with Void return.
This PR silences those warnings by removing `@discardableResult`.