### PR TITLE
TARGETED_DEVICE_FAMILY correction in ObjcExceptionBridging for tvOS & watchOS

### DIFF
--- a/XCGLogger.xcodeproj/project.pbxproj
+++ b/XCGLogger.xcodeproj/project.pbxproj
@@ -1742,6 +1742,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
 		};
@@ -1772,6 +1773,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;
 		};
@@ -1801,6 +1803,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
 		};
@@ -1831,6 +1834,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This PR corrects an issue I encountered when building this framework via Carthage for tvOS.  It also seems like it's an issue for watchOS too.  It only affects the ObjcExceptionBridging targets as XCGLogger itself is fine.

In ObjcExceptionBridging, the (inherited) `TARGETED_DEVICE_FAMILY` property was set to `1,2` - this value is fine for iOS & macOS, but according to [this very helpful comment](https://github.com/Carthage/Carthage/issues/950#issuecomment-176291457), watchOS is meant to have the value `4` & tvOS is meant to have the value `3`.