### PR TITLE
Fix AutoRotatingFileDestination over-rotation, over-appendMarkering, potentially crashing

### DIFF
--- a/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
+++ b/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
@@ -88,12 +88,12 @@ open class AutoRotatingFileDestination: FileDestination {
     open class var defaultLogFolderURL: URL {
         #if os(OSX)
             let osxURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponet("log")
-            createArchivedLogDirectoryIfNeeded(at: osxURL)
+            try? FileManager.default.createDirectory(at: osxURL, withIntermediateDirectories: true)
             return osxURL
         #elseif os(iOS) || os(tvOS) || os(watchOS)
             let urls = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
             let otherURL = urls[urls.endIndex - 1].appendingPathComponent("log")
-            createArchivedLogDirectoryIfNeeded(at: otherURL)
+            try? FileManager.default.createDirectory(at: otherURL, withIntermediateDirectories: true)
             return otherURL
         #endif
     }
@@ -140,24 +140,8 @@ open class AutoRotatingFileDestination: FileDestination {
         }
         
         // Because we always start by appending, regardless of the shouldAppend setting, we now need to handle the cases where we don't want to append or that we have now reached the rotation threshold for our current log file
-        if !shouldAppend || shouldRotate() { {
+        if !shouldAppend || shouldRotate() {
             rotateFile()
-        }
-    }
-
-    // MARK: - Folder / File Handling Methods
-    /// Create a directory at a path for archived/rotated logs
-    ///
-    /// - Parameters:   None.
-    ///     - url:   URL where directory should exist
-    ///
-    /// - Returns:      Nothing.
-    ///
-    open class func createArchivedLogDirectoryIfNeeded(at url: URL) {
-        do {
-            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
-        } catch let error as NSError {
-            XCGLogger.default._logln("Unable to create archived log directory \(url.path): \(error.localizedDescription)", level: .error)
         }
     }
     

--- a/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
+++ b/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
@@ -88,12 +88,12 @@ open class AutoRotatingFileDestination: FileDestination {
     open class var defaultLogFolderURL: URL {
         #if os(OSX)
             let osxURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponet("log")
-            createArchivedLogDirectory(at: osxURL)
+            createArchivedLogDirectoryIfNeeded(at: osxURL)
             return osxURL
         #elseif os(iOS) || os(tvOS) || os(watchOS)
             let urls = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
             let otherURL = urls[urls.endIndex - 1].appendingPathComponent("log")
-            createArchivedLogDirectory(at: otherURL)
+            createArchivedLogDirectoryIfNeeded(at: otherURL)
             return otherURL
         #endif
     }
@@ -153,7 +153,7 @@ open class AutoRotatingFileDestination: FileDestination {
     ///
     /// - Returns:      Nothing.
     ///
-    open class func createArchivedLogDirectory(at url: URL) {
+    open class func createArchivedLogDirectoryIfNeeded(at url: URL) {
         do {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
         } catch let error as NSError {

--- a/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
+++ b/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
@@ -140,7 +140,7 @@ open class AutoRotatingFileDestination: FileDestination {
         }
         
         // Because we always start by appending, regardless of the shouldAppend setting, we now need to handle the cases where we don't want to append or that we have now reached the rotation threshold for our current log file
-        if shouldRotate() || !shouldAppend {
+        if !shouldAppend || shouldRotate() { {
             rotateFile()
         }
     }

--- a/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
+++ b/Sources/XCGLogger/Destinations/AutoRotatingFileDestination.swift
@@ -87,10 +87,14 @@ open class AutoRotatingFileDestination: FileDestination {
     /// A default folder for storing archived logs if one isn't supplied
     open class var defaultLogFolderURL: URL {
         #if os(OSX)
-            return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("log")
+            let osxURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponet("log")
+            createArchivedLogDirectory(at: osxURL)
+            return osxURL
         #elseif os(iOS) || os(tvOS) || os(watchOS)
             let urls = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
-            return urls[urls.endIndex - 1].appendingPathComponent("log")
+            let otherURL = urls[urls.endIndex - 1].appendingPathComponent("log")
+            createArchivedLogDirectory(at: otherURL)
+            return otherURL
         #endif
     }
 
@@ -101,7 +105,8 @@ open class AutoRotatingFileDestination: FileDestination {
         currentLogStartTimeInterval = Date().timeIntervalSince1970
         self.archiveSuffixDateFormatter = archiveSuffixDateFormatter
         self.shouldAppend = shouldAppend
-        self.appendMarker = appendMarker
+        // Do not keep the append marker around after the superclass uses it otherwise it is logged twice and it is not needed during rotation.
+        self.appendMarker = nil
 
         guard let writeToFileURL = writeToFileURL else { return }
 
@@ -123,16 +128,9 @@ open class AutoRotatingFileDestination: FileDestination {
         if archiveFolderURL == nil {
             archiveFolderURL = type(of: self).defaultLogFolderURL
         }
-
-        guard shouldAppend else {
-            // Because we always start by appending, regardless of the shouldAppend setting, we now need to handle the case where we don't want to append, so we immediate rotate the file
-            // this is just as if we didn't append, but prevents the super class from wiping the contents of the log file when opening it
-            rotateFile()
-            return
-        }
-
+        
         do {
-            // Since we're appending, we need to get the starting file count and start interval of the current log
+            // Initialize starting values for file size and start time so shouldRotate calculations are valid
             let fileAttributes: [FileAttributeKey: Any] = try FileManager.default.attributesOfItem(atPath: filePath)
             currentLogFileSize = fileAttributes[.size] as? UInt64 ?? 0
             currentLogStartTimeInterval = (fileAttributes[.creationDate] as? Date ?? Date()).timeIntervalSince1970
@@ -140,13 +138,29 @@ open class AutoRotatingFileDestination: FileDestination {
         catch let error as NSError {
             owner?._logln("Unable to determine current file attributes of log file: \(error.localizedDescription)", level: .warning)
         }
-
-        if shouldRotate() {
+        
+        // Because we always start by appending, regardless of the shouldAppend setting, we now need to handle the cases where we don't want to append or that we have now reached the rotation threshold for our current log file
+        if shouldRotate() || !shouldAppend {
             rotateFile()
         }
     }
 
     // MARK: - Folder / File Handling Methods
+    /// Create a directory at a path for archived/rotated logs
+    ///
+    /// - Parameters:   None.
+    ///     - url:   URL where directory should exist
+    ///
+    /// - Returns:      Nothing.
+    ///
+    open class func createArchivedLogDirectory(at url: URL) {
+        do {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        } catch let error as NSError {
+            XCGLogger.default._logln("Unable to create archived log directory \(url.path): \(error.localizedDescription)", level: .error)
+        }
+    }
+    
     /// Scan the log folder and delete log files that are no longer relevant.
     ///
     /// - Parameters:   None.
@@ -248,6 +262,9 @@ open class AutoRotatingFileDestination: FileDestination {
     ///     - false:    The log file doesn't have to be rotated.
     ///
     open func shouldRotate() -> Bool {
+        // Do not rotate until critical setup has been completed so that we do not accidentally rotate once to the defaultLogFolderURL before determining the desired log location
+        guard archiveFolderURL != nil else { return false }
+        
         // File Size
         guard currentLogFileSize < targetMaxFileSize else { return true }
 


### PR DESCRIPTION
If the default log folder didn't exist, the `AutoRotatingFileDestination` would infinitely attempt to write to that nonexistent folder until the application crashed: https://github.com/DaveWoodCom/XCGLogger/issues/208. There were also issues where appending resulted in logging the append marker too often and rotating too often.

Please look at https://github.com/DaveWoodCom/XCGLogger/pull/207 first as that is also required to make AutoRotatingFileDestination useful in practice.