### PR TITLE
Fix warning `Redundant conformance constraint ‘Key’: ‘Hashable’`

### DIFF
--- a/Sources/XCGLogger/Misc/Optional/UserInfoHelpers.swift
+++ b/Sources/XCGLogger/Misc/Optional/UserInfoHelpers.swift
@@ -87,7 +87,7 @@ public struct Dev: UserInfoTaggingProtocol {
 
 /// Overloaded operator to merge userInfo compatible dictionaries together
 /// Note: should correctly handle combining single elements of the same key, or an element and an array, but will skip sets
-public func |<Key: Hashable, Value: Any> (lhs: Dictionary<Key, Value>, rhs: Dictionary<Key, Value>) -> Dictionary<Key, Any> {
+public func |<Key: Any, Value: Any> (lhs: Dictionary<Key, Value>, rhs: Dictionary<Key, Value>) -> Dictionary<Key, Any> {
     var mergedDictionary: Dictionary<Key, Any> = lhs
 
     rhs.forEach { key, rhsValue in


### PR DESCRIPTION
Using Xcode 9 beta 4 we had one warning. 

Tests succeed on Xcode 8.3.3 and Xcode 9 beta 4.

I assume that the use of `Key` as the key of the `Dictionary` already requires `Hashable`.