### PR TITLE
Restrict APIs to those allowed in app extensions for macOS and tvOS

### DIFF
--- a/XCGLogger.xcodeproj/project.pbxproj
+++ b/XCGLogger.xcodeproj/project.pbxproj
@@ -1218,6 +1218,7 @@
 		5515A3E41BA119FA0047BA31 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1241,6 +1242,7 @@
 		5515A3E51BA119FA0047BA31 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
@@ -1264,6 +1266,7 @@
 		554DF42B19D76FE7005708BE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1290,6 +1293,7 @@
 		554DF42C19D76FE7005708BE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;


### PR DESCRIPTION
#41 enabled the app extension API restriction for iOS. Looking at the configuration currently in the project file, the restriction was enabled for all builds of the ObjExceptionBridge and all builds of XCGLogger targets except macOS and tvOS.

This PR enables the restriction to only app extension compatible APIs for XCGLogger on macOS and tvOS, so that all targets are configured equivalently.