### PR TITLE
Use swift_version instead of pod_target_xcconfig

### DIFF
--- a/XCGLogger.podspec
+++ b/XCGLogger.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
     spec.social_media_url = 'http://twitter.com/DaveWoodX'
     spec.platforms = { :ios => '8.0', :watchos => '2.0', :tvos => '9.0' }
     spec.requires_arc = true
-    spec.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
+    spec.swift_version = '4.2'
 
     spec.source = { :git => 'https://github.com/DaveWoodCom/XCGLogger.git', :tag => "#{spec.version}" }
 


### PR DESCRIPTION
Otherwise, the used `swift_version` depends on swift version of the app's target.

see https://github.com/CocoaPods/CocoaPods/issues/7327