### PR TITLE
added type: .dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,11 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "XCGLogger",
+            type: .dynamic,
             targets: ["XCGLogger"]),
         .library(
             name: "ObjcExceptionBridging",
+            type: .dynamic,
             targets: ["ObjcExceptionBridging"]),
     ],
     dependencies: [


### PR DESCRIPTION
Added `type: .dynamic` to .library entries. This solves a compile error in Xcode 11.4 when linking to a static library on multiple project targets. It builds XCGLogger as dynamic libraries that can now be linked against multiple targets. There could be caveats I'm not aware of using this technique so do what you want with it.