### PR TITLE
SwiftPM: Add list of supported platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "XCGLogger",
     platforms: [
-        .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "XCGLogger",
+    platforms: [
+        .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
This helps when Swift and Xcode build the framework.

Added `.macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)`, which is compatible with the platforms declared in the podspec.

Set `swift-tools-version` in the header to `5.0` because this is the first version that supports the `platforms` argument.