### PR TITLE
Fix file close crash

### DIFF
--- a/Sources/XCGLogger/Destinations/FileDestination.swift
+++ b/Sources/XCGLogger/Destinations/FileDestination.swift
@@ -135,7 +135,11 @@ open class FileDestination: BaseQueuedDestination {
     ///
     private func closeFile() {
         logFileHandle?.synchronizeFile()
-        logFileHandle?.closeFile()
+        if #available(iOS 13.0, *) {
+          try? logFileHandle?.close()
+        } else {
+          logFileHandle?.closeFile()
+        }
         logFileHandle = nil
     }
 


### PR DESCRIPTION
Fixes file close crash seen only on iOS 13

```
Fatal Exception: NSFileHandleOperationException
*** -[NSConcreteFileHandle synchronizeFile]: No such file or directory
```
```
Fatal Exception: NSFileHandleOperationException
0  CoreFoundation                 0x1af63d344 (Missing)
1  libobjc.A.dylib                0x1af352cc0 (Missing)
2  Foundation                     0x1af9e0050 (Missing)
3  Foundation                     0x1af9dfac0 (Missing)
4  Foundation                     0x1af9a369c (Missing)
5  XCGLogger                      0x10665cf80 FileDestination.rotateFile(to:closure:) + 138 (FileDestination.swift:138)
6  XCGLogger                      0x106653f28 AutoRotatingFileDestination.rotateFile() + 237 (AutoRotatingFileDestination.swift:237)
7  XCGLogger                      0x10665a57c closure #1 in BaseQueuedDestination.output(logDetails:message:) + 41 (BaseQueuedDestination.swift:41)
8  XCGLogger                      0x10665a320 BaseQueuedDestination.output(logDetails:message:) + 48 (BaseQueuedDestination.swift:48)
9  XCGLogger                      0x1066585cc BaseDestination.process(logDetails:) + 124 (BaseDestination.swift:124)
10 XCGLogger                      0x106659dbc protocol witness for DestinationProtocol.process(logDetails:) in conformance BaseDestination (<compiler-generated>)
11 XCGLogger                      0x1066698e8 XCGLogger.logln(_:functionName:fileName:lineNumber:userInfo:closure:) + 348 (XCGLogger.swift:348)
12 XCGLogger                      0x10666955c XCGLogger.logln(_:functionName:fileName:lineNumber:userInfo:closure:) + 325 (XCGLogger.swift:325)
13 XCGLogger                      0x10666b240 XCGLogger.verbose(_:functionName:fileName:lineNumber:userInfo:)
14 XCGLogger                      0x10666a850 XCGLogger.verbose(_:functionName:fileName:lineNumber:userInfo:)
```