### PR TITLE
Add support for per destination-based formatter

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/XCGLogger/Destinations/BaseDestination.swift
+++ b/Sources/XCGLogger/Destinations/BaseDestination.swift
@@ -52,6 +52,9 @@ open class BaseDestination: DestinationProtocol, CustomDebugStringConvertible {
     /// Option: whether or not to output the date the log was created
     open var showDate: Bool = true
 
+    /// Option: Destionation based formatter, igonores `XCGLogger.owner.dateFormatter` if set
+    open var dateFormatter: DateFormatter?
+
     /// Option: override descriptions of log levels
     open var levelDescriptions: [XCGLogger.Level: String] = [:]
 
@@ -82,7 +85,7 @@ open class BaseDestination: DestinationProtocol, CustomDebugStringConvertible {
         var extendedDetails: String = ""
 
         if showDate {
-            extendedDetails += "\((owner.dateFormatter != nil) ? owner.dateFormatter!.string(from: logDetails.date) : logDetails.date.description) "
+            extendedDetails += "\(self.formatted(date: logDetails.date)) "
         }
 
         if showLevel {
@@ -137,7 +140,7 @@ open class BaseDestination: DestinationProtocol, CustomDebugStringConvertible {
         var extendedDetails: String = ""
 
         if showDate {
-            extendedDetails += "\((owner.dateFormatter != nil) ? owner.dateFormatter!.string(from: logDetails.date) : logDetails.date.description) "
+            extendedDetails += "\(self.formatted(date: logDetails.date)) "
         }
 
         if showLevel {
@@ -163,6 +166,20 @@ open class BaseDestination: DestinationProtocol, CustomDebugStringConvertible {
     ///
     open func isEnabledFor(level: XCGLogger.Level) -> Bool {
         return level >= self.outputLevel
+    }
+
+    /// Use the correct formatter (first `self`, then `owner` to format the date.
+    ///
+    /// - Parameters:
+    ///     - date: the date for format
+    ///
+    /// - Returns:
+    ///     - string:   `date` formatted using "best" formatter, or in worst case `.description` if noone is set.
+    ///
+    private func formatted(date: Date) -> String {
+        (dateFormatter ?? owner?.dateFormatter).map {
+            $0.string(from: date)
+        } ?? date.description
     }
 
     // MARK: - Methods that must be overridden in subclasses


### PR DESCRIPTION
This is useful for example in an effort to shorten then logs in the console but without sacrificing details written to logs on file.