### PR TITLE
fix(privacyInfo): Fix for privacy info file location to be moved to resource bundle

### DIFF
--- a/ObjcExceptionBridging.podspec
+++ b/ObjcExceptionBridging.podspec
@@ -28,6 +28,8 @@ Pod::Spec.new do |spec|
     # ObjcExceptionBridging Framework
     spec.subspec 'ObjcExceptionBridging' do |core|
         core.source_files = 'Sources/ObjcExceptionBridging/**/*.{h,m}'
-        core.resource = 'Sources/ObjcExceptionBridging/PrivacyInfo.xcprivacy'
+        core.resource_bundle = {
+            "#{spec.name}_Privacy" => "Sources/ObjcExceptionBridging/PrivacyInfo.xcprivacy"
+        }
     end
 end

--- a/XCGLogger.podspec
+++ b/XCGLogger.podspec
@@ -32,7 +32,10 @@ Pod::Spec.new do |spec|
         core.dependency 'ObjcExceptionBridging'
         core.source_files = 'Sources/XCGLogger/**/*.{swift}'
         core.exclude_files = 'Sources/XCGLogger/**/Optional/*.{swift}'
-        core.resource = '.swift-version', 'Sources/XCGLogger/PrivacyInfo.xcprivacy'
+        core.resource = '.swift-version'
+        core.resource_bundle = {
+            "#{spec.name}_Privacy" => "Sources/XCGLogger/PrivacyInfo.xcprivacy"
+        }
     end
 
     # An experimental subspec to include helpers for using the UserInfo dictionary with log messages, tagging logs with tags and/or developers


### PR DESCRIPTION
Fix for privacy info file location to be moved to resource bundle

Current location of the PrivacyInfo file cause it to be copied to the app main bundle and when the app already has its own PrivacyInfo file, it fails to compile with following error:

❌  error: Multiple commands produce '/Users/distiller/Library/Developer/Xcode/DerivedData/AppiOS-gavnxsjrntlwlmevysoidgzotogr/Build/Intermediates.noindex/ArchiveIntermediates/AppiOS/InstallationBuildProductsLocation/Applications/AppiOS.app/PrivacyInfo.xcprivacy'
